### PR TITLE
Make the package startup well-behaved

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,11 +3,10 @@
 
 .noGenerics <- TRUE
 
-.onLoad <-
+.onAttach <-
 function(libname,
          pkgname)
 {
-  #! J'ai l'impression que dans les good practices,  packageStartupMessage doit plutôt être appelée dans .onAttach...
   packageStartupMessage("\nThis is package 'modeest' written by P. PONCET.\nFor a complete list of functions, use 'library(help = \"modeest\")' or 'help.start()'.\n")
 }
 
@@ -16,4 +15,3 @@ function(libpath)
 {
   library.dynam.unload("modeest", libpath)
 }
-


### PR DESCRIPTION
`packageStartupMessage` [should be called in `.onAttach`](https://stat.ethz.ch/R-manual/R-devel/library/base/html/ns-hooks.html), not `.onLoad`, as the now-deleted comment correctly surmised.

This is actually relevant because it creates hard-to-silence messages even when run non-interactively, [as discussed on Stack Overflow](http://stackoverflow.com/q/42699619/1968).